### PR TITLE
Update dist.ini instructions

### DIFF
--- a/lib/ExtUtils/MakeMaker/Dist/Zilla/Develop.pm
+++ b/lib/ExtUtils/MakeMaker/Dist/Zilla/Develop.pm
@@ -31,11 +31,9 @@ commands to generate your test suite, for example), and tell Dist::Zilla to
 replace it with a real C<Makefile.PL> when you're actually ready to build a
 real distribution. To do this, make sure you're still using the
 L<MakeMaker|Dist::Zilla::Plugin::MakeMaker> plugin, either directly or through
-a pluginbundle like L<@Basic|Dist::Zilla::PluginBundle::Basic>, and add this to
-your C<dist.ini>:
-
-  [PruneFiles]
-  filenames = Makefile.PL
+a pluginbundle like L<@Basic|Dist::Zilla::PluginBundle::Basic>, and add the
+C<exclude_filename = Makefile.PL> option to your F<dist.ini> where you use
+C<[GatherDir]>.
 
 In addition, this module also intercepts the C<install> and C<dist> rules in
 the generated Makefile to run the appropriate Dist::Zilla commands


### PR DESCRIPTION
For some plugins that add Makefile.PL, [PruneFiles] will remove the new Makefile.PL being added, rather than removing the old one that exists in the repo. Excluding the file from [GatherDir] will always work, so this is a safer recommendation.
